### PR TITLE
change uv_poll_init

### DIFF
--- a/src/uv_timeout_poll.c
+++ b/src/uv_timeout_poll.c
@@ -94,7 +94,11 @@ int uv_timeout_poll_start(uv_timeout_poll_t* handle, int events, uv_timeout_poll
 	handle->cb = cb;
 
 	if (handle->init_flags & UV_USE_POLL) {
+#ifdef _WIN32
+		ret = uv_poll_init_socket(loop, &handle->poll, fd);
+#else
 		ret = uv_poll_start(&handle->poll, events, __uv_timeout_poll_poll_cb);
+#endif
 		if (ret < 0) {
 			// At first, the timer was started before the poll so we had to close the timer here.
 			// actually this was not a good practice, because the user might free the whole uv_timeout_poll_t


### PR DESCRIPTION
libuv has function named uv_poll_init_socket initialize the handle using a socket descriptor,but not use uv_poll_init.Use uv_poll_init will got an  windows socket error num-10038,which mean fd is  not a socket.
Not test in other platform.